### PR TITLE
Random fixes

### DIFF
--- a/LibFont.js
+++ b/LibFont.js
@@ -218,7 +218,11 @@ const LibFont = (() => {
 
     glyph = (codepoint) => {
       const index = this.glyphIndex(codepoint);
+      if (index === null)
+        return null;
       const width = this.glyphWidths.at(index);
+      if (width === 0)
+        return null;
       return new Glyph(
         new GlyphBitmap(this.rows, index * this.glyphHeight, width, this.glyphHeight),
         0, width, this.glyphWidth)
@@ -270,9 +274,12 @@ const LibFont = (() => {
     drawTextInto = (canvasCtx, drawX, drawY, text) => {
       let x = 0;
       [...(text)].map(c => {
-        const glyph = this.glyph(c.codePointAt(0));
-        glyph.bitmap.paintInto(canvasCtx, drawX + x, drawY)
-        x += glyph.advance + this.glyphSpacing;
+        const glyph = this.glyph(c.codePointAt(0)) ?? this.glyph(0xFFFD);
+        if (glyph) {
+          // Note: The glyph may still not be present when the font doesn't have 0xFFFD REPLACEMENT CHARACTER.
+          glyph.bitmap.paintInto(canvasCtx, drawX + x, drawY)
+          x += glyph.advance + this.glyphSpacing;
+        }
       })
     }
   }

--- a/index.html
+++ b/index.html
@@ -193,7 +193,7 @@
           <td id="prop-max-glyph-width"></td>
         </tr>
         <tr>
-          <th><b>Basline</b></th>
+          <th><b>Baseline</b></th>
           <td id="prop-basline"></td>
         </tr>
         <tr>
@@ -205,7 +205,7 @@
           <td id="prop-presentation-size"></td>
         </tr>
         <tr>
-          <th><b>Weigh:</b></th>
+          <th><b>Weight</b></th>
           <td id="prop-weight"></td>
         </tr>
         <tr>


### PR DESCRIPTION
Mainly this:
![image](https://user-images.githubusercontent.com/42967349/168129429-bb91c183-4e94-478d-8e43-dfb8fc42dec5.png)
(If the 0xFFFD glyph doesn't exist, the character is skipped as previously)