### PR TITLE
README: Add glyphWidth to properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ LibFont.BitmapFont.loadFont('./KaticaBold10.font').then(font => {
 
 - `font.name`
 - `font.family`
+- `font.glyphWidth`
 - `font.glyphHeight`
 - `font.minGlyphWidth`
 - `font.maxGlyphWidth`


### PR DESCRIPTION
Copied the properties from readme when implementing LibFont.js on https://fonts.serenityos.net/AtaraxiaBold10/metadata and noticed glyphWidth was missing :^)